### PR TITLE
Update MSRV due to dependency failure

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -11,7 +11,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.56.1 # MSRV
+          - 1.57.0 # MSRV
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Error was: package `os_str_bytes v6.2.0` cannot be built because it requires rustc 1.57.0 or newer, while the currently active rustc version is 1.56.1