### PR TITLE
Fixes for performance and valuation report deserialization

### DIFF
--- a/crates/sharesight-examples/src/bin/report_performance.rs
+++ b/crates/sharesight-examples/src/bin/report_performance.rs
@@ -1,0 +1,79 @@
+use clap::Parser;
+use sharesight_examples::init_logger;
+use sharesight_reqwest::Client;
+use sharesight_types::{
+    Performance, PerformanceParameters, PerformanceSuccess, PortfolioList, PortfolioListSuccess,
+    DEFAULT_API_HOST,
+};
+
+/// Generate a 'performance' report using the sharesight API
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// The host to use to access the API.
+    #[clap(long, default_value = DEFAULT_API_HOST)]
+    api_host: String,
+    /// The name of the portfolio to report the performance for.
+    portfolio_name: String,
+    /// The access token to use the api.
+    access_token: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    init_logger();
+
+    let args = Args::parse();
+    let client = Client::new_with_token_and_host(args.access_token, args.api_host);
+    let portfolio_name = args.portfolio_name;
+
+    let PortfolioListSuccess { portfolios, .. } = client
+        .execute::<PortfolioList, PortfolioListSuccess>(&())
+        .await?;
+
+    let portfolio = portfolios.iter().find(|p| p.name == portfolio_name);
+
+    if let Some(portfolio) = portfolio {
+        let performance_parameters = PerformanceParameters {
+            start_date: None,
+            end_date: None,
+            portfolio_id: portfolio.id,
+            consolidated: None,
+            include_sales: Some(true),
+            grouping: None,
+            custom_group_id: None,
+        };
+        let performance_report = client
+            .execute::<Performance, PerformanceSuccess>(&performance_parameters)
+            .await?;
+
+        println!(
+            "Performance report for portfolio '{}' from {} to {}",
+            portfolio.name, performance_report.start_date, performance_report.end_date
+        );
+        println!("{:#?}", performance_report);
+    } else {
+        eprint!("Unknown portfolio: {}, ", portfolio_name);
+
+        let mut names = portfolios.iter().map(|p| p.name.as_str());
+
+        match (names.next(), names.next_back()) {
+            (Some(name_start), Some(name_end)) => {
+                eprint!("the portfolios are: {}", name_start);
+                for name in names {
+                    eprint!(", {}", name);
+                }
+                eprintln!(" or {}", name_end);
+            }
+            (Some(name), None) => {
+                eprintln!("the only portfolio is: {}", name);
+            }
+            (None, None) => {
+                eprintln!("there are no portfolios");
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    Ok(())
+}

--- a/crates/sharesight-examples/src/bin/report_valuation.rs
+++ b/crates/sharesight-examples/src/bin/report_valuation.rs
@@ -1,0 +1,78 @@
+use clap::Parser;
+use sharesight_examples::init_logger;
+use sharesight_reqwest::Client;
+use sharesight_types::{
+    PortfolioList, PortfolioListSuccess, Valuation, ValuationParameters, ValuationSuccess,
+    DEFAULT_API_HOST,
+};
+
+/// Generate a 'valuation' report using the sharesight API
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// The host to use to access the API.
+    #[clap(long, default_value = DEFAULT_API_HOST)]
+    api_host: String,
+    /// The name of the portfolio to report the valuation for.
+    portfolio_name: String,
+    /// The access token to use the api.
+    access_token: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    init_logger();
+
+    let args = Args::parse();
+    let client = Client::new_with_token_and_host(args.access_token, args.api_host);
+    let portfolio_name = args.portfolio_name;
+
+    let PortfolioListSuccess { portfolios, .. } = client
+        .execute::<PortfolioList, PortfolioListSuccess>(&())
+        .await?;
+
+    let portfolio = portfolios.iter().find(|p| p.name == portfolio_name);
+
+    if let Some(portfolio) = portfolio {
+        let performance_parameters = ValuationParameters {
+            portfolio_id: portfolio.id,
+            consolidated: None,
+            include_sales: Some(true),
+            grouping: None,
+            custom_group_id: None,
+            balance_date: None,
+        };
+        let performance_report = client
+            .execute::<Valuation, ValuationSuccess>(&performance_parameters)
+            .await?;
+
+        println!(
+            "Valuation report for portfolio '{}' as of {}",
+            portfolio.name, performance_report.balance_date
+        );
+        println!("{:#?}", performance_report);
+    } else {
+        eprint!("Unknown portfolio: {}, ", portfolio_name);
+
+        let mut names = portfolios.iter().map(|p| p.name.as_str());
+
+        match (names.next(), names.next_back()) {
+            (Some(name_start), Some(name_end)) => {
+                eprint!("the portfolios are: {}", name_start);
+                for name in names {
+                    eprint!(", {}", name);
+                }
+                eprintln!(" or {}", name_end);
+            }
+            (Some(name), None) => {
+                eprintln!("the only portfolio is: {}", name);
+            }
+            (None, None) => {
+                eprintln!("there are no portfolios");
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    Ok(())
+}

--- a/crates/sharesight-generate/assets/api_data.json
+++ b/crates/sharesight-generate/assets/api_data.json
@@ -14867,7 +14867,7 @@
             },
             {
               "group": "200 Success",
-              "type": "String",
+              "type": "Integer",
               "optional": false,
               "field": "portfolio_id",
               "description": "<p>The portfolio id</p>"
@@ -14965,10 +14965,10 @@
             },
             {
               "group": "200 Success",
-              "type": "Date",
+              "type": "Boolean",
               "optional": false,
               "field": "include_sales",
-              "description": "<p>Include sales (format <code>YYYY-MM-DD</code>)</p>"
+              "description": "<p>Include sales</p>"
             },
             {
               "group": "200 Success",
@@ -14979,7 +14979,7 @@
             },
             {
               "group": "200 Success",
-              "type": "String",
+              "type": "Integer",
               "optional": false,
               "field": "holdings.id",
               "description": "<p>The id of this holding</p>"
@@ -14993,7 +14993,7 @@
             },
             {
               "group": "200 Success",
-              "type": "String",
+              "type": "Integer",
               "optional": false,
               "field": "holdings.instrument_id",
               "description": "<p>A unique id identifying the instrument</p>"
@@ -16754,7 +16754,7 @@
             },
             {
               "group": "200 Success",
-              "type": "String",
+              "type": "Integer",
               "optional": false,
               "field": "portfolio_id",
               "description": "<p>The portfolio id</p>"
@@ -16789,7 +16789,7 @@
             },
             {
               "group": "200 Success",
-              "type": "String",
+              "type": "Integer",
               "optional": false,
               "field": "holdings.id",
               "description": "<p>The id of this holding</p>"
@@ -16803,7 +16803,7 @@
             },
             {
               "group": "200 Success",
-              "type": "String",
+              "type": "Integer",
               "optional": false,
               "field": "holdings.instrument_id",
               "description": "<p>A unique id identifying the instrument</p>"

--- a/crates/sharesight-types/src/types.rs
+++ b/crates/sharesight-types/src/types.rs
@@ -4327,9 +4327,8 @@ pub struct PerformanceSuccess {
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub id: String,
     /// The portfolio id
-    #[serde(default)]
-    #[serde_as(deserialize_as = "DefaultOnNull")]
-    pub portfolio_id: String,
+    #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
+    pub portfolio_id: i64,
     /// Grouping id or name
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull")]
@@ -4362,9 +4361,8 @@ pub struct PerformanceSuccess {
     /// End date (format `YYYY-MM-DD`)
     #[serde_as(as = "DeserializeDate")]
     pub end_date: NaiveDate,
-    /// Include sales (format `YYYY-MM-DD`)
-    #[serde_as(as = "DeserializeDate")]
-    pub include_sales: NaiveDate,
+    /// Include sales
+    pub include_sales: bool,
     /// List of holdings.
     pub holdings: Vec<PerformanceHoldingsSuccess>,
     /// List of cash accounts. This includes Unsettled Trades and Unpaid Payout Adjustments.
@@ -4377,17 +4375,15 @@ pub struct PerformanceSuccess {
 #[derive(Debug, Clone, Deserialize)]
 pub struct PerformanceHoldingsSuccess {
     /// The id of this holding
-    #[serde(default)]
-    #[serde_as(deserialize_as = "DefaultOnNull")]
-    pub id: String,
+    #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
+    pub id: i64,
     /// The Sharesight symbol for the held instrument
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub symbol: String,
     /// A unique id identifying the instrument
-    #[serde(default)]
-    #[serde_as(deserialize_as = "DefaultOnNull")]
-    pub instrument_id: String,
+    #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
+    pub instrument_id: i64,
     /// The code for the market the held instrument is listed on
     pub market: Market,
     /// The group value this instrument has been placed in - note that the field name will be the group type
@@ -4698,9 +4694,8 @@ pub struct ValuationSuccess {
     #[serde_as(as = "DeserializeDate")]
     pub balance_date: NaiveDate,
     /// The portfolio id
-    #[serde(default)]
-    #[serde_as(deserialize_as = "DefaultOnNull")]
-    pub portfolio_id: String,
+    #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
+    pub portfolio_id: i64,
     /// Grouping id or name
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull")]
@@ -4723,17 +4718,15 @@ pub struct ValuationSuccess {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ValuationHoldingsSuccess {
     /// The id of this holding
-    #[serde(default)]
-    #[serde_as(deserialize_as = "DefaultOnNull")]
-    pub id: String,
+    #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
+    pub id: i64,
     /// The Sharesight symbol for the held instrument
     #[serde(default)]
     #[serde_as(deserialize_as = "DefaultOnNull")]
     pub symbol: String,
     /// A unique id identifying the instrument
-    #[serde(default)]
-    #[serde_as(deserialize_as = "DefaultOnNull")]
-    pub instrument_id: String,
+    #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
+    pub instrument_id: i64,
     /// The code for the market the held instrument is listed on
     pub market: Market,
     /// The group value this instrument has been placed in - note that the field name will be the group type


### PR DESCRIPTION
Thanks for putting this library together! I noticed a few return types defined in `api_data.json` didn't match the response from the server which prevented them from being deserialized. There are probably more since I can see several `*_id` fields marked as strings, but these are the only 2 reports i've tested and can confirm as working so i've left the others unchanged for now.